### PR TITLE
Restart timers in 'check_solver'

### DIFF
--- a/decaptcha/app.py
+++ b/decaptcha/app.py
@@ -66,11 +66,6 @@ def decaptcher_response(captcha_code=None, result_code=None):
     return "{result_code}|0|0|0|0|{captcha_code}".format(**locals())
 
 
-def start_expired_timers(storage):
-    storage.start_expired_timer("fails", settings.FAILS_CHECK_INTERVAL)
-    storage.start_expired_timer("minbid", settings.MINBID_CHECK_INTERVAL)
-
-
 @app.route('/', method='POST')
 def solve_captcha():
     """
@@ -87,7 +82,6 @@ def solve_captcha():
     pict = request.files['pict'].file.read()
     pict_type = request.POST.get('pict_type')
     storage = RedisStorage()
-    start_expired_timers(storage)
 
     solver_name = request.query.get("upstream_service")
     if solver_name:

--- a/decaptcha/checkers.py
+++ b/decaptcha/checkers.py
@@ -75,13 +75,17 @@ def check_solver(service_name, storage):
     if service_name == LOWEST_SOLVER:
         return None
 
-    no_uses = not storage.get_uses(service_name)
-    if service_name == Solvers.ANTIGATE\
-            and (no_uses or storage.timer_expired("minbid"))\
-            and not is_antigate_minbid_ok():
-        return CheckErrors.MINBID
+    if service_name == Solvers.ANTIGATE and storage.timer_expired("minbid"):
+        log.debug(u"Запускаем таймер 'minbid'")
+        storage.start_expired_timer("minbid", settings.MINBID_CHECK_INTERVAL)
+        if not is_antigate_minbid_ok():
+            log.debug(u"[%s] Minbid высок", service_name)
+            return CheckErrors.MINBID
 
-    if storage.timer_expired("fails")\
-            and not is_fails_percentage_ok(service_name, storage):
-        return CheckErrors.FAILS
+    if storage.timer_expired("fails"):
+        log.debug(u"Запускаем таймер 'fails'")
+        storage.start_expired_timer("fails", settings.FAILS_CHECK_INTERVAL)
+        if not is_fails_percentage_ok(service_name, storage):
+            log.debug(u"[%s] Превышен процент ошибок", service_name)
+            return CheckErrors.FAILS
     return None

--- a/decaptcha/test/test_app.py
+++ b/decaptcha/test/test_app.py
@@ -97,7 +97,6 @@ def test_solve_captcha(app):
 
     check_request = _patch("app.check_request")
     decaptcher_response = _patch("app.decaptcher_response")
-    start_expired_timers = _patch("app.start_expired_timers")
     solvers = _patch("app.solvers")
     check_solver = _patch("app.check_solver")
     storage = _patch("app.RedisStorage")()
@@ -119,7 +118,6 @@ def test_solve_captcha(app):
     assert check_request.called
     assert decaptcher_response.called
     assert not solve.called
-    assert not start_expired_timers.called
     reset_mocks(locals())
 
     # моделирование запроса с валидными POST-данными
@@ -130,7 +128,6 @@ def test_solve_captcha(app):
     decaptcher_response.return_value = "resp1"
     app.post('/', some_data)
     #
-    assert start_expired_timers.called
     assert solvers.get_highest_notblocked.call_count == 2
     assert not solvers.get_by_name.called
     assert check_solver.call_count == 2
@@ -150,7 +147,6 @@ def test_solve_captcha(app):
     solve.side_effect = ["captchacode2"]
     app.post('/?upstream_service=captchabot', some_data)
     #
-    assert start_expired_timers.called
     assert solvers.get_by_name.called
     assert not solvers.get_highest_notblocked.called
     assert not check_solver.called
@@ -170,7 +166,6 @@ def test_solve_captcha(app):
     decaptcher_response.return_value = "resp1"
     app.post('/', some_data)
     #
-    assert start_expired_timers.called
     assert storage.incr_uses.call_count\
             == storage.incr_fails.call_count\
             == solve.call_count\


### PR DESCRIPTION
Timers need for periodic actions: check minbid and fails percentage. Previously timers erroneously restarts automatically at the beginning of request processing so these periodic actions didn't launch. 
